### PR TITLE
fixing typing bug on saveFile

### DIFF
--- a/uno2iec/interface.cpp
+++ b/uno2iec/interface.cpp
@@ -272,7 +272,7 @@ void Interface::saveFile()
 			serCmdIOBuf[bytesInBuffer++] = m_iec.receive();
 			interrupts();
 			done = (m_iec.state() bitand IEC::eoiFlag) or (m_iec.state() bitand IEC::errorFlag);
-		} while(bytesInBuffer < sizeof(serCmdIOBuf) and not done);
+		} while((bytesInBuffer < 0xf0) and not done);
 		// indicate to media host that we want to write a buffer. Give the total length including the heading 'W'+length bytes.
 		serCmdIOBuf[1] = bytesInBuffer;
 		COMPORT.write((const byte*)serCmdIOBuf, bytesInBuffer);


### PR DESCRIPTION
i had troubles sending files greater than 255 bytes from the commodore64 to the arduino. the problem was caused by an always true comparison because sizeof(serCmdIOBuf) is MAX_BYTES_PER_REQUEST, aka 256, but bytesInBuffer can hold only 255, so the cycle guard will collapse into an always-true comparison.

artificially limiting the "packet" size to 0xf0 worked for my toy example. of course this is only a workaround, but it can be a starting point for a better patch.