### PR TITLE
Fixes Listing Theme / Adds Commodore C16 

### DIFF
--- a/dirlistthemingconsts.hpp
+++ b/dirlistthemingconsts.hpp
@@ -26,7 +26,11 @@ C128_80Theme = { "\n                     COMMODORE BASIC V7.0 122365 BYTES FREE\
 
 Plus4Theme = { "\n COMMODORE BASIC V3.5 60671 BYTES FREE\n"
 							 " 3-PLUS-1 ON KEY F1\n\n"
-							 "READY.\n", "12pt \"Pet Me 64\"", 0, 4, 15, 16};
+                             "READY.\n", "12pt \"Pet Me 64\"", 0, 4, 15, 16},
+
+C16Theme = { "\n COMMODORE BASIC V3.5 12277 BYTES FREE\n"
+                             "READY.\n", "12pt \"Pet Me 64\"", 0, 14, 1, 16};
+
 
 // BLACK, WHITE, RED, CYAN, PURPLE, GREEN, BLUE, YELLOW
 // ORANGE, BROWN, LIGHT RED, DARK GRAY, MEDIUM GRAY, LIGHT GREEN, LIGHT BLUE, LIGHT GRAY

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -187,22 +187,23 @@ MainWindow::MainWindow(QWidget* parent) :
 		on_resetArduino_clicked();
 #endif
 
-	emulatorPalettes["vice"] = viceColors;
-	emulatorPalettes["ccs64"] = ccs64Colors;
-	emulatorPalettes["frodo"] = frodoColors;
-	emulatorPalettes["c64s"] = c64sColors;
-	emulatorPalettes["c64hq"] = c64hqColors;
-	emulatorPalettes["godot"] = godotColors;
-	emulatorPalettes["pc64"] = pc64Colors;
-	emulatorPalettes["default"] = defaultColors;
-	emulatorPalettes["vic20"] = vic20Colors;
-	emulatorPalettes["plus4"] = plus4Colors;
+    // palettes and themes must be named exactly after action labels
+    emulatorPalettes["&vice"] = viceColors;
+    emulatorPalettes["ccs6&4"] = ccs64Colors;
+    emulatorPalettes["&frodo"] = frodoColors;
+    emulatorPalettes["c&64s"] = c64sColors;
+    emulatorPalettes["&c64hq"] = c64hqColors;
+    emulatorPalettes["&godot"] = godotColors;
+    emulatorPalettes["&pc64"] = pc64Colors;
+    emulatorPalettes["&default"] = defaultColors;
+    emulatorPalettes["vic&20"] = vic20Colors;
+    emulatorPalettes["p&lus4"] = plus4Colors;
 
-	machineThemes["VIC 20"] = &Vic20Theme;
-	machineThemes["C 64"] = &C64Theme;
-	machineThemes["C 128"] = &C128Theme;
-	machineThemes["C 128 (80 Col)"] = &C128_80Theme;
-	machineThemes["Plus 4"] = &Plus4Theme;
+    machineThemes["&VIC 20"] = &Vic20Theme;
+    machineThemes["&C 64"] = &C64Theme;
+    machineThemes["C &128"] = &C128Theme;
+    machineThemes["C 128 (&80 Col)"] = &C128_80Theme;
+    machineThemes["&Plus 4"] = &Plus4Theme;
 
 	setupActionGroups();
 
@@ -1419,8 +1420,9 @@ void MainWindow::cbmCursorVisible(bool visible)
 
 void MainWindow::getMachineAndPaletteTheme(CbmMachineTheme*& pMachine, const QRgb*& pEmulatorPalette)
 {
-	pMachine = 0;
-	pEmulatorPalette = 0;
+    // setting up valid defaults for invalid settings
+    pMachine = &C64Theme;
+    pEmulatorPalette = ccs64Colors;
 	EmulatorPaletteMap::iterator itEmulatorPalette(emulatorPalettes.find(m_appSettings.emulatorPalette));
 	CbmMachineThemeMap::iterator itMachineTheme(machineThemes.find(m_appSettings.cbmMachine));
 	if(itEmulatorPalette not_eq emulatorPalettes.end())

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -204,6 +204,7 @@ MainWindow::MainWindow(QWidget* parent) :
     machineThemes["C &128"] = &C128Theme;
     machineThemes["C 128 (&80 Col)"] = &C128_80Theme;
     machineThemes["&Plus 4"] = &Plus4Theme;
+    machineThemes["C 1&6"] = &C16Theme;
 
 	setupActionGroups();
 
@@ -245,7 +246,8 @@ void MainWindow::setupActionGroups()
 	cbmMachineGroup->addAction(ui->actionVic_20);
 	cbmMachineGroup->addAction(ui->actionC_128_80_Col);
 	cbmMachineGroup->addAction(ui->actionPlus_4);
-	connect(cbmMachineGroup, SIGNAL(triggered(QAction*)), this, SLOT(onCbmMachineSelected(QAction*)));
+    cbmMachineGroup->addAction(ui->actionC_16);
+    connect(cbmMachineGroup, SIGNAL(triggered(QAction*)), this, SLOT(onCbmMachineSelected(QAction*)));
 	selectActionByName(ui->menuMachine->actions(), m_appSettings.cbmMachine);
 } // setupActionGroup
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>634</width>
+    <width>673</width>
     <height>609</height>
    </rect>
   </property>
@@ -427,31 +427,32 @@ p, li { white-space: pre-wrap; }
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>634</width>
-     <height>21</height>
+     <width>673</width>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuMain">
     <property name="title">
-     <string>Main</string>
+     <string>&amp;Main</string>
     </property>
     <widget class="QMenu" name="menuDirectory_Listing_Colors">
      <property name="title">
-      <string>Directory Listing Theme</string>
+      <string>&amp;Directory Listing Theme</string>
      </property>
      <widget class="QMenu" name="menuMachine">
       <property name="title">
-       <string>Machine</string>
+       <string>&amp;Machine</string>
       </property>
       <addaction name="actionVic_20"/>
       <addaction name="actionCommodore_64"/>
       <addaction name="actionC128"/>
       <addaction name="actionC_128_80_Col"/>
       <addaction name="actionPlus_4"/>
+      <addaction name="actionC_16"/>
      </widget>
      <widget class="QMenu" name="menuEmulator_Palette">
       <property name="title">
-       <string>Emulator Palette</string>
+       <string>&amp;Emulator Palette</string>
       </property>
       <addaction name="actionInternal"/>
       <addaction name="actionDefault"/>
@@ -493,7 +494,7 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="minimumSize">
     <size>
-     <width>535</width>
+     <width>673</width>
      <height>200</height>
     </size>
    </property>
@@ -505,7 +506,7 @@ p, li { white-space: pre-wrap; }
     <set>Qt::BottomDockWidgetArea|Qt::TopDockWidgetArea</set>
    </property>
    <property name="windowTitle">
-    <string>Event Log</string>
+    <string>Event &amp;Log</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>8</number>
@@ -690,7 +691,7 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/icons/icons/exit.png</normaloff>:/icons/icons/exit.png</iconset>
    </property>
    <property name="text">
-    <string>Quit</string>
+    <string>&amp;Quit</string>
    </property>
    <property name="shortcut">
     <string>Esc</string>
@@ -702,7 +703,7 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/icons/icons/1541.ico</normaloff>:/icons/icons/1541.ico</iconset>
    </property>
    <property name="text">
-    <string>About</string>
+    <string>&amp;About</string>
    </property>
   </action>
   <action name="actionSettings">
@@ -711,7 +712,7 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/icons/icons/settings.png</normaloff>:/icons/icons/settings.png</iconset>
    </property>
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -733,7 +734,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Disk Write Protected</string>
+    <string>Disk &amp;Write Protected</string>
    </property>
    <property name="toolTip">
     <string>Prevents writing files on disk image or native file system.</string>
@@ -747,7 +748,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>frodo</string>
+    <string>&amp;frodo</string>
    </property>
   </action>
   <action name="actionVic_20">
@@ -755,7 +756,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>VIC 20</string>
+    <string>&amp;VIC 20</string>
    </property>
   </action>
   <action name="actionCommodore_64">
@@ -763,7 +764,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>C 64</string>
+    <string>&amp;C 64</string>
    </property>
   </action>
   <action name="actionC128">
@@ -771,7 +772,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>C 128</string>
+    <string>C &amp;128</string>
    </property>
   </action>
   <action name="actionVice">
@@ -779,7 +780,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>vice</string>
+    <string>&amp;vice</string>
    </property>
   </action>
   <action name="actionCcs64">
@@ -787,7 +788,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>ccs64</string>
+    <string>ccs6&amp;4</string>
    </property>
   </action>
   <action name="actionPc64">
@@ -795,7 +796,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>pc64</string>
+    <string>&amp;pc64</string>
    </property>
   </action>
   <action name="actionC64hq">
@@ -803,7 +804,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>c64hq</string>
+    <string>&amp;c64hq</string>
    </property>
   </action>
   <action name="actionC64s">
@@ -811,7 +812,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>c64s</string>
+    <string>c&amp;64s</string>
    </property>
   </action>
   <action name="actionDefault">
@@ -819,7 +820,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>default</string>
+    <string>&amp;default</string>
    </property>
   </action>
   <action name="actionInternal">
@@ -827,7 +828,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>internal</string>
+    <string>&amp;internal</string>
    </property>
   </action>
   <action name="actionGodot">
@@ -835,7 +836,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>godot</string>
+    <string>&amp;godot</string>
    </property>
   </action>
   <action name="actionVic20">
@@ -843,7 +844,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>vic20</string>
+    <string>vic&amp;20</string>
    </property>
   </action>
   <action name="actionC_128_80_Col">
@@ -851,7 +852,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>C 128 (80 Col)</string>
+    <string>C 128 (&amp;80 Col)</string>
    </property>
   </action>
   <action name="actionPlus_4">
@@ -859,7 +860,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Plus 4</string>
+    <string>&amp;Plus 4</string>
    </property>
   </action>
   <action name="actionPlus4">
@@ -867,7 +868,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>plus4</string>
+    <string>p&amp;lus4</string>
    </property>
   </action>
   <action name="actionSingle_file_mount">
@@ -876,13 +877,21 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/icons/icons/floppy_mount.png</normaloff>:/icons/icons/floppy_mount.png</iconset>
    </property>
    <property name="text">
-    <string>Mount specific file</string>
+    <string>&amp;Mount specific file</string>
    </property>
    <property name="toolTip">
     <string>Mount specific image file on any location</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+M</string>
+   </property>
+  </action>
+  <action name="actionC_16">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>C 1&amp;6</string>
    </property>
   </action>
  </widget>

--- a/uno2iec/global_defines.h
+++ b/uno2iec/global_defines.h
@@ -26,7 +26,7 @@ typedef unsigned long ulong;
 // What it does is showing loading progress on the display and some nice scrolling of the filename and other
 // stuff on the display. The display hardware can be bought cheap here at dx.com:
 // http://dx.com/p/max7219-dot-matrix-module-w-5-dupont-lines-184854
-#define USE_LED_DISPLAY
+//#define USE_LED_DISPLAY
 
 // Define this if you want to configure a HC-06 bluetooth module connected to the arduino and make the communication
 // with the commodore machine completely wireless. Defining this will configure the BT module in the main sketch.
@@ -38,7 +38,7 @@ typedef unsigned long ulong;
 //#define EXPERIMENTAL_SPEED_FIX
 
 // For serial communication. 115200 Works fine, but probably use 57600 for bluetooth dongle for stability.
-#define DEFAULT_BAUD_RATE 57600
+#define DEFAULT_BAUD_RATE 115200
 #define SERIAL_TIMEOUT_MSECS 1000
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284__) \


### PR DESCRIPTION
Using the master checkout I noticed the host app to crash instantly when ever selecting an option from the "Directory Theme Listing" menu. Digging down the issue I noticed the keys between the ui QAction text and ``emulatorPalettes[]`` (respective ``machineThemes[]``) did not match due to the quick key & symbols. 

Therefore I corrected the keys in the code and added valid fallback values to ``getMachineAndPaletteTheme`` for ensuring the application not to crash on unknown settings. 

This request also contains a small commit for adding the lesser known commodore C16. Its similar to the Plus/4 but 16k, no rom software and different overscan color.